### PR TITLE
More permissive column names

### DIFF
--- a/lib/Database.js
+++ b/lib/Database.js
@@ -97,7 +97,7 @@ var Database = module.exports = Class.extend({
 
     var columns = [];
     if (fields) {
-      if (typeof fields == 'string') {
+      if (typeof fields === 'string') {
         fields = fields.split(/\*,\*/g);
       }
       fields.forEach(function (name) {
@@ -117,12 +117,13 @@ var Database = module.exports = Class.extend({
         columns.push(fields[fieldName].as);
       }
     }
+
     fields = columns.join(',');
 
     where = this.getWhereSql(model, filters, where);
 
     var max = require('../ormy')._MAX_RESULTS;
-    if (typeof limit == 'number') {
+    if (typeof limit === 'number') {
       limit = Math.min(limit, max);
     }
     else if (limit instanceof Array) {
@@ -223,28 +224,28 @@ var Database = module.exports = Class.extend({
     var sets = [];
     for (var fieldName in item) {
       var field = model.fields[fieldName];
-      if (field && (fieldName != exclude)) {
+      if (field && (fieldName !== exclude)) {
         var value = item[fieldName];
         if (item[fieldName] === null) {
           sets.push(field.column + '=NULL');
         }
         else {
           value = ('' + value).replace(/'/g, "\\'");
-          sets.push(field.column + "='" + value + "'");
+          sets.push('`' + field.column + "`='" + value + "'");
         }
       }
     }
-    if (model.createdField && (mode == 'create')) {
-      sets.push(model.createdField.name + "=NOW()");
+    if (model.createdField && (mode === 'create')) {
+      sets.push('`' + model.createdField.name +'`' + "=NOW()");
     }
     if (model.modifiedField) {
-      sets.push(model.modifiedField.name + "=NOW()");
+      sets.push('`' + model.modifiedField.name + '`'+ "=NOW()");
     }
     return ' SET ' + sets.join(',');
   },
 
   quote: function quote(value) {
-    if (typeof value == 'string') {
+    if (typeof value === 'string') {
       value = value.replace(/'/g, "\\'");
     }
     return "'" + value + "'";
@@ -262,20 +263,20 @@ var Database = module.exports = Class.extend({
         if (value instanceof Array) {
           var operator = value[0];
           if (/^(=|!=|<|>|<=|>=|LIKE|NOT LIKE)$/i.test(operator)) {
-            condition = column + ' ' + operator + ' ' + db.quote(value[1]);
+            condition = '`' + column + '`' + ' ' + operator + ' ' + db.quote(value[1]);
           }
           else if (/^(IS NULL|IS NOT NULL)$/i.test(operator)) {
-            condition = column + ' ' + operator;
+            condition = '`' + column + '`' + ' ' + operator;
           }
-          else if (operator == 'BETWEEN') {
-            condition = column + ' BETWEEN ' + db.quote(value[1]) + ' AND ' + db.quote(value[2]);
+          else if (operator === 'BETWEEN') {
+            condition = '`' + column + '`' + ' BETWEEN ' + db.quote(value[1]) + ' AND ' + db.quote(value[2]);
           }
-          else if (operator == 'IN') {
-            condition = column + ' IN (' + value[1].join(',') + ')';
+          else if (operator === 'IN') {
+            condition = '`' + column + '`' + ' IN (' + value[1].join(',') + ')';
           }
         }
         else {
-          condition = column + '=' + db.quote(value);
+          condition = '`' + column + '`' + '=' + db.quote(value);
         }
         if (condition) {
           conditions.push(condition);

--- a/lib/Field.js
+++ b/lib/Field.js
@@ -1,3 +1,4 @@
+'use strict';
 var Class = require('./Class');
 
 /**
@@ -7,7 +8,7 @@ var Field = module.exports = Class.extend({
 
   init: function init(model, config, name) {
     var field = this;
-    if (typeof config == 'string') {
+    if (typeof config === 'string') {
       config = {type: config};
     }
     field.name = name;
@@ -18,7 +19,7 @@ var Field = module.exports = Class.extend({
       field[key] = config[key];
     }
 
-    field.as = field.column + (field.column == name ? '' : ' as ' + name);
+    // Wrappting field column name with ` so that column names can be more permissive
+    field.as = '`' + field.column + '`' + (field.column === name ? '' : ' as ' + name);
   }
-
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "ormy"
   ],
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "ormy.js",
   "homepage": "http://github.com/zerious/ormy",
   "repository": "http://github.com/zerious/ormy.git",


### PR DESCRIPTION
Changes now allows column names to more permissive.
For example, 'ad[someId]' or 'ad.someId' is now allowed
